### PR TITLE
docs: remove references to drawing_tool in Text class

### DIFF
--- a/examples/beam1.py
+++ b/examples/beam1.py
@@ -48,7 +48,6 @@ def main() -> None:
     )
 
     fig.add(beam)
-    # beam.draw_dimensions(drawing_tool)
     fig.show()
 
 

--- a/examples/pendulum1.py
+++ b/examples/pendulum1.py
@@ -11,9 +11,6 @@ W = 6.0
 logging.basicConfig(level=logging.INFO)
 
 
-# drawing_tool.set_grid(True)
-
-
 def main() -> None:
     L = 5 * H / 7  # length
     P = ps.Point(W / 6, 0.85 * H)  # rotation point

--- a/examples/vehicle_dim.py
+++ b/examples/vehicle_dim.py
@@ -8,7 +8,6 @@ w_1 = 5  # position of front wheel
 
 
 # TODO : draw grids
-# drawing_tool.set_grid(True)
 def main() -> None:
     c = ps.Point(w_1, R)
 

--- a/pysketcher/_text.py
+++ b/pysketcher/_text.py
@@ -5,18 +5,14 @@ from pysketcher._style import TextStyle
 
 
 class Text(Shape):
-    """Some text which appears on the drawing at the specified location.
+    """Place `text` on the drawing at the Point(x, y) `position`
 
-    Place `text` at the (x,y) point `position`, with the given
-    fontsize (0 indicates that the default fontsize set in drawing_tool
-    is to be used). The text is centered around `position` if `alignment` is
-    'center'; if 'left', the text starts at `position`, and if
-    'right', the right and of the text is located at `position`.
+    The `text` will be drawn in the given `direction`
 
     Args:
         text: The text to be displayed.
-        position: The position at which the text should be displayed.
-        direction: The direction in which the text should flow.
+        position: Point, The position the text will be displayed at.
+        direction: Point, The direction the text will flow to.
 
     Examples:
         >>> fig = ps.Figure(0.0, 4.0, 0.0, 4.0, MatplotlibBackend)


### PR DESCRIPTION
reverted all Nov 2 commits save part of  `557196f` examples/vehicle_dim.py, delete  `# drawing_tool.set_grid(True)`

installed and tested `pre-commit`, which issued a warning:

> [WARNING] The 'rev' field of repo 'https://gitlab.com/pycqa/flake8' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.

running `pre-commit autoupdate` as suggested removed the warning, but modified some files.  I did not want to commit them, but the following error gave me no choice:

> [ERROR] Your pre-commit configuration is unstaged.

I believe these changes were okay so I committed them.

In short, this PR changes the `class Text` docstring in `_text.py`, and deleted `# drawing_tool.set_grid(True)` in `examples/beam1.py`

I merged master into this branch (3 commits) so it can be merged directly, if so you choose.
